### PR TITLE
Fix display of chunks with decimal durations

### DIFF
--- a/src/components/Day.vue
+++ b/src/components/Day.vue
@@ -11,7 +11,10 @@
       <div class="col-auto">
         {{ chunk.task.name }}
       </div>
-      <div class="col-auto">{{ chunk.duration }} min</div>
+      <div class="col-auto">
+        <!-- Rounds to 2 decimal places -->
+        {{ Math.round(chunk.duration * 100) / 100 }} min
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Resolves #26 

Chunks with decimal durations are now displayed with durations rounded to the nearest hundredth.