### PR TITLE
Tasks now have effort

### DIFF
--- a/src/components/TaskModal.vue
+++ b/src/components/TaskModal.vue
@@ -17,17 +17,27 @@
         </div>
         <div class="row mb-2">
           <b-input-group prepend="Duration" append="minutes" class="col">
-            <b-form-input v-model="task.duration" type="number" />
+            <b-form-input
+              v-model="task.duration"
+              type="number"
+              :number="true"
+            />
           </b-input-group>
         </div>
         <div class="row mb-2">
           <b-input-group prepend="Chunks" class="col">
-            <b-form-input v-model="task.chunks" />
+            <b-form-input v-model="task.chunks" type="number" :number="true" />
           </b-input-group>
         </div>
         <div class="row">
           <b-input-group prepend="Due" class="col">
             <b-form-datepicker v-model="task.due" value-as-date />
+          </b-input-group>
+        </div>
+        <hr />
+        <div class="row mb-2">
+          <b-input-group class="col" prepend="Effort">
+            <b-form-input v-model="task.effort" type="number" :number="true" />
           </b-input-group>
         </div>
       </div>

--- a/src/store/index.vuex.ts
+++ b/src/store/index.vuex.ts
@@ -126,18 +126,9 @@ export class Store extends VuexModule {
     super();
 
     if (localStorage["tasks"]) {
-      const retrievedData: {
-        name: string;
-        chunks: string;
-        duration: number;
-        due: string;
-      }[] = JSON.parse(localStorage["tasks"]);
-
-      this.tasks = retrievedData.map((task) => {
+      this.tasks = JSON.parse(localStorage["tasks"]).map((task: UserTask) => {
         return {
-          name: task.name,
-          chunks: parseInt(task.chunks),
-          duration: task.duration,
+          ...task,
           due: new Date(task.due),
         };
       });

--- a/src/types/Chunk.ts
+++ b/src/types/Chunk.ts
@@ -13,6 +13,10 @@ export default class Chunk {
     this.date = date;
   }
 
+  get effort(): number {
+    return this.duration * this.task.effort;
+  }
+
   get desc(): string {
     return `${this.duration} minute chunk of task ${
       this.task.name

--- a/src/types/Task.ts
+++ b/src/types/Task.ts
@@ -3,4 +3,5 @@ export default class UserTask {
   duration = 60;
   chunks = 1;
   due: Date = new Date();
+  effort = 1;
 }

--- a/src/types/Task.ts
+++ b/src/types/Task.ts
@@ -4,4 +4,8 @@ export default class UserTask {
   chunks = 1;
   due: Date = new Date();
   effort = 1;
+
+  get totalEffort(): number {
+    return this.effort * this.duration;
+  }
 }


### PR DESCRIPTION
Tasks now have an effort. A tasks's total effort is the product of its effort and duration. Later, tasks will be chunked with effort in mind.

This also fixes a bug where certain task values were stored as strings when they should have been numbers in local storage.