### PR TITLE
Days can have specific start and end times

### DIFF
--- a/src/components/DayModal.vue
+++ b/src/components/DayModal.vue
@@ -18,12 +18,38 @@
       </div>
       <div class="">
         <div class="row">
-          <div class="col">Time</div>
+          <div class="col">Time spent</div>
           <div class="col">{{ time }} minutes</div>
         </div>
         <div class="row">
           <div class="col">Total effort</div>
           <div class="col">{{ effort }}</div>
+        </div>
+        <div class="row">
+          <div class="col">Total available time</div>
+          <div class="col">{{ timeAvailable }} minutes</div>
+        </div>
+        <div class="row">
+          <b-input-group
+            class="col chunk-modal-time-edit-top"
+            prepend="Start time"
+          >
+            <b-form-timepicker />
+            <b-input-group-append is-text>
+              <b-form-checkbox class="mr-n2" />
+            </b-input-group-append>
+          </b-input-group>
+        </div>
+        <div class="row">
+          <b-input-group
+            class="col chunk-modal-time-edit-bottom"
+            prepend="End time"
+          >
+            <b-form-timepicker />
+            <b-input-group-append is-text>
+              <b-form-checkbox class="mr-n2" />
+            </b-input-group-append>
+          </b-input-group>
         </div>
       </div>
     </b-modal>
@@ -33,6 +59,7 @@
 import { Component, Vue } from "vue-property-decorator";
 import vxm from "@/store/index.vuex";
 import Chunk from "@/types/Chunk";
+import DateUtils from "@/util/DateUtils";
 
 @Component
 export default class DayModal extends Vue {
@@ -63,6 +90,31 @@ export default class DayModal extends Vue {
   get effort(): number {
     return this.chunks.reduce((prev, curr) => prev + curr.effort, 0);
   }
+
+  get timeAvailable(): number {
+    return vxm.store.settings.timeOnDay(
+      DateUtils.constructDate(this.day, this.month)
+    );
+  }
 }
 </script>
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.chunk-modal-time-edit-top > .input-group-prepend > .input-group-text {
+  border-bottom-left-radius: 0;
+}
+.chunk-modal-time-edit-top > .input-group-append > .input-group-text {
+  border-bottom-right-radius: 0;
+}
+
+.chunk-modal-time-edit-bottom > .input-group-prepend > .input-group-text {
+  border-top-left-radius: 0;
+}
+
+.chunk-modal-time-edit-bottom > .input-group-append > .input-group-text {
+  border-top-right-radius: 0;
+}
+
+.chunk-modal-time-edit-bottom {
+  margin-top: -1px; // Avoid double border
+}
+</style>

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -156,37 +156,21 @@ export default class SettingsModal extends Vue {
   }
 
   updateStart(time: string) {
-    const extracted = time.match(/([0-9]{2}):([0-9]{2})/);
-    if (!extracted || !extracted[1] || !extracted[2]) {
-      return;
-    }
-    const hour = parseInt(extracted[1]);
-    const minute = parseInt(extracted[2]);
-
-    vxm.store.settings.baseStartTime = hour * 60 + minute;
+    vxm.store.settings.baseStartTime = vxm.store.settings.stringToTime(time);
     vxm.store.uploadSettings();
   }
 
   get startTime(): string {
-    const start = vxm.store.settings.baseStartTime;
-    return `${Math.floor(start / 60)}:${Math.floor(start % 60)}`;
+    return vxm.store.settings.timeToString(vxm.store.settings.baseStartTime);
   }
 
   updateEnd(time: string) {
-    const extracted = time.match(/([0-9]{2}):([0-9]{2})/);
-    if (!extracted || !extracted[1] || !extracted[2]) {
-      return;
-    }
-    const hour = parseInt(extracted[1]);
-    const minute = parseInt(extracted[2]);
-
-    vxm.store.settings.baseEndTime = hour * 60 + minute;
+    vxm.store.settings.baseEndTime = vxm.store.settings.stringToTime(time);
     vxm.store.uploadSettings();
   }
 
   get endTime(): string {
-    const end = vxm.store.settings.baseEndTime;
-    return `${Math.floor(end / 60)}:${Math.floor(end % 60)}`;
+    return vxm.store.settings.timeToString(vxm.store.settings.baseEndTime);
   }
 
   startTimes: string[] = [];

--- a/src/store/index.vuex.ts
+++ b/src/store/index.vuex.ts
@@ -114,10 +114,11 @@ export class Store extends VuexModule {
 
         // Assign to the latest possible day (if none work, will be due date) by default
         for (let d = 0; d <= daysUntilDue; d++) {
-          const dayOfWeek = DateUtils.offsetDayOfWeek(DateUtils.currentDate, d);
           const dayHasTime =
             getTotalTime(chunksByDay[d]) + chunkDuration <=
-            this.settings.dailyTimes[dayOfWeek];
+            this.settings.timeOnDay(
+              DateUtils.applyDayOffset(d, DateUtils.currentDate)
+            );
 
           if (dayHasTime) {
             dayToAssign = d;
@@ -128,10 +129,11 @@ export class Store extends VuexModule {
 
         // Finds the day with that has the lowest effort compared to the next and sets that as the chunk's due date
         for (let d = 0; d <= daysUntilDue; d++) {
-          const dayOfWeek = DateUtils.offsetDayOfWeek(DateUtils.currentDate, d);
           const dayHasTime =
             getTotalTime(chunksByDay[d]) + chunkDuration <=
-            this.settings.dailyTimes[dayOfWeek];
+            this.settings.timeOnDay(
+              DateUtils.applyDayOffset(d, DateUtils.currentDate)
+            );
 
           if (dayHasTime) {
             anyDaysWork = true;

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -56,6 +56,10 @@ export default class Settings {
     return this.stringToTime(str);
   }
 
+  timeToString(time: number): string {
+    return `${Math.floor(time / 60)}:${Math.floor(time % 60)}`;
+  }
+
   timeOnDay(day: Date): number {
     const numKey = DateUtils.stripTime(day).getTime();
     const dayOfWeek = DateUtils.dayOfWeek(day);

--- a/src/util/DateUtils.ts
+++ b/src/util/DateUtils.ts
@@ -64,4 +64,11 @@ export default class DateUtils {
   static offsetDayOfWeek(date: Date, offset: number): number {
     return this.dayOfWeek(this.applyDayOffset(offset, date));
   }
+
+  static constructDate(day: number, month: number): Date {
+    const template = this.stripTime(new Date());
+    template.setDate(day);
+    template.setMonth(month);
+    return template;
+  }
 }

--- a/src/util/DateUtils.ts
+++ b/src/util/DateUtils.ts
@@ -65,6 +65,12 @@ export default class DateUtils {
     return this.dayOfWeek(this.applyDayOffset(offset, date));
   }
 
+  /**
+   * Creates a Date from a given day and month. The year is set to the current year and time is stripped ({@link stripTime})
+   * @param day the day of the new date
+   * @param month the month of the new date
+   * @returns a new date with the given date and month
+   */
   static constructDate(day: number, month: number): Date {
     const template = this.stripTime(new Date());
     template.setDate(day);


### PR DESCRIPTION
Days can now have specific start and end times that override the day of the week's start time (or default start time if the day of the week isn't set). Resolves #33 and #71.