### PR TITLE
Update hotkey code

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -66,18 +66,8 @@ export default class App extends Vue {
   }
 
   mounted() {
-    window.addEventListener("keydown", (ev: KeyboardEvent) => {
+    window.addEventListener("keyup", (ev: KeyboardEvent) => {
       const changelogModal = this.$refs.changelogModal as ChangelogModal;
-
-      if (ev.keyCode === 37) {
-        if (vxm.store.changelogModalShown) {
-          changelogModal.backVersion();
-        }
-      } else if (ev.keyCode === 39) {
-        if (vxm.store.changelogModalShown) {
-          changelogModal.forwardVersion();
-        }
-      }
 
       let fn = (
         {
@@ -86,8 +76,19 @@ export default class App extends Vue {
           r: () => this.newReminder(),
           s: () => this.$bvModal.show("settings-modal"),
           h: () => this.$bvModal.show("help-modal"),
+          ArrowRight: () => {
+            if (vxm.store.changelogModalShown) {
+              changelogModal.forwardVersion();
+            }
+          },
+          ArrowLeft: () => {
+            if (vxm.store.changelogModalShown) {
+              changelogModal.backVersion();
+            }
+          },
         } as Record<string, () => void>
       )[ev.key];
+
       if (fn) fn();
     });
   }

--- a/src/types/Changelog.ts
+++ b/src/types/Changelog.ts
@@ -168,4 +168,10 @@ Typing a hotkey in the description field in the task modal could open modals/tri
     description:
       "Updates styles so that reminder-colored elements darken on hover",
   },
+  {
+    version: "3.6.9",
+    title: "Hotkey fix",
+    description:
+      "Refreshing the page with a keyboard shortcut no longer brings up the reminder modal",
+  },
 ];


### PR DESCRIPTION
I actually will allow hotkeys to trigger if multiple keys are pressed. There's no reason for this not to happen (considering that modals don't launch when the user types into a field). A more elegant solution to the problem is to trigger hotkeys on keyup, not keydown. Keyup will not trigger when the user refreshes the page (as the page can't receive the event).