### PR TITLE
Fix task loading bug

### DIFF
--- a/src/store/index.vuex.ts
+++ b/src/store/index.vuex.ts
@@ -269,6 +269,7 @@ export class Store extends VuexModule {
         return {
           ...task,
           due: new Date(task.due),
+          startDate: task.startDate ? new Date(task.startDate) : null,
           lockedChunks: task.lockedChunks.map((lockedChunk) => {
             return {
               date: new Date(lockedChunk.date),

--- a/src/types/Changelog.ts
+++ b/src/types/Changelog.ts
@@ -179,4 +179,9 @@ Typing a hotkey in the description field in the task modal could open modals/tri
     title: "Tasks have a started completion date",
     description: "Users can now set dates before which tasks cannot start",
   },
+  {
+    version: "3.7.1",
+    title: "Bug fix",
+    description: "Fix bug where tasks didn't load properly from local storage",
+  },
 ];


### PR DESCRIPTION
#206 wasn't actually going to be an issue because of how `DateUtils.daysBetween` works.

I did end up fixing another issue.